### PR TITLE
more useful error message when NAs break str_pad

### DIFF
--- a/R/pad-trim.r
+++ b/R/pad-trim.r
@@ -23,6 +23,9 @@ str_pad <- function(string, width, side = "left", pad = " ") {
   stopifnot(length(width) == 1)
   stopifnot(length(side) == 1)
   stopifnot(length(pad) == 1)
+  if( any( is.na( string ) ) ) {
+    stop( "String cannot contain missings" )
+  }
   if (str_length(pad) != 1) {
     stop("pad must be single character single")
   }


### PR DESCRIPTION
missing values break str_dup inside str_pad..  currently it displays-

> str_pad( c( 'hi' , NA , 'hello' ) , 5 )
> Error in rep.int(string[i], times[i]) : invalid 'times' value

i didn't propose putting this inside check_string() because other functions (such as str_length and str_sub) that use check_string() do accept missing values

hope this makes sense..thanks!
