### PR TITLE
Fix the `str_sub<-` function (Address issue #20)

### DIFF
--- a/R/sub.r
+++ b/R/sub.r
@@ -91,5 +91,6 @@ str_sub <- function(string, start = 1L, end = -1L) {
     str_sub(string, end = start - 1L), 
     value, 
     ifelse(rep(end, length(string)) == -1L, "", str_sub(mytext, start = end + 1L))
+  )
         
 }


### PR DESCRIPTION
 `ifelse` within `str_sub<-` was returning only the first entry in the character vector because it returns a vector if the same shape as the logical test. This was resulting in the observed output in issue #20 
