### PR TITLE
Ensure str_trim returns a character when character(0) is input (Address issue #31)

### DIFF
--- a/R/checks.r
+++ b/R/checks.r
@@ -5,9 +5,6 @@ check_string <- function(string) {
 
   if (!is.character(string))
     string <- as.character(string)
-  
-  if (length(string) == 0)
-    string <- ""
 
   string
 }

--- a/R/pad-trim.r
+++ b/R/pad-trim.r
@@ -55,6 +55,10 @@ str_pad <- function(string, width, side = "left", pad = " ") {
 #' str_trim("\n\nString with trailing and leading white space\n\n")
 str_trim <- function(string, side = "both") {
   string <- check_string(string)
+  
+  if (length(string) == 0)
+    string <- ""
+  
   stopifnot(length(side) == 1)
 
   side <- match.arg(side, c("left", "right", "both"))


### PR DESCRIPTION
Addresses Issue #31. I tried putting the logic statement in `check_string`, but this broke tests of special cases with `character(0)` in `str_match` and `str_detect`.
