### PR TITLE
Fix existing partial matches in stringr.

### DIFF
--- a/tests/testthat/test-match.r
+++ b/tests/testthat/test-match.r
@@ -1,7 +1,7 @@
 context("Matching groups")
 
 set.seed(1410)
-num <- matrix(sample(9, 10 * 10, rep = T), ncol = 10)
+num <- matrix(sample(9, 10 * 10, replace = T), ncol = 10)
 num_flat <- apply(num, 1, str_c, collapse = "")
 
 phones <- str_c(

--- a/tests/testthat/test-pad.r
+++ b/tests/testthat/test-pad.r
@@ -3,7 +3,7 @@ context("Test padding")
 test_that("long strings are unchanged", {
   lengths <- sample(40:100, 10)
   strings <- vapply(lengths, function(x)
-    str_c(letters[sample(26, x, rep = T)], collapse = ""),
+    str_c(letters[sample(26, x, replace = T)], collapse = ""),
     character(1))
 
   padded <- str_pad(strings, width = 30)

--- a/tests/testthat/test-word.r
+++ b/tests/testthat/test-word.r
@@ -1,0 +1,8 @@
+context("Word extraction")
+
+test_that("word extraction", {
+  expect_equal("walk", word("walk the moon"))
+  expect_equal("walk", word("walk the moon", 1))
+  expect_equal("moon", word("walk the moon", 3))
+  expect_equal("the moon", word("walk the moon", 2, 3))
+})


### PR DESCRIPTION
This fixes all the matches I spotted (and adds an extra test, so that we see partial matches in `word` here instead of in dependencies).

There's also some wrapping code that sets and unsets options, so this doesn't immediately arise again -- that should probably move into `testthat`.