### PR TITLE
Bugfix + small feature

### DIFF
--- a/R/interp.R
+++ b/R/interp.R
@@ -176,7 +176,9 @@ eval_interp_matches <- function(matches, env)
 extract_expressions <- function(matches)
 {
   # Parse function for text argument as first argument.
-  parse_text <- function(text) parse(text = text)
+  parse_text <- function(text)
+    tryCatch(parse(text = text),
+             error = function(e) stop(conditionMessage(e), call. = FALSE))
 
   # string representation of the expressions (without the possible formats).
   strings  <- gsub("\\$(\\[.+?\\])?\\{", "", matches)

--- a/R/interp.R
+++ b/R/interp.R
@@ -109,6 +109,11 @@ interp_placeholders <- function(string)
                   start = starts,
                   stop  = c(starts[-1L] - 1L, nchar(string)))
 
+  # If there are nested placeholders, each part will not contain a full
+  # placeholder in which case we report invalid string interpolation template.
+  if (any(!grepl("\\$(\\[.*?\\])?\\{.+\\}", parts)))
+    stop("Invalid template string for interpolation.", call. = FALSE)
+
   # For each part, find the opening and closing braces.
   opens  <- lapply(strsplit(parts, ""), function(v) which(v == "{"))
   closes <- lapply(strsplit(parts, ""), function(v) which(v == "}"))

--- a/man/str_interp.Rd
+++ b/man/str_interp.Rd
@@ -42,6 +42,11 @@ str_interp("One value, ${value1}, and then another, ${value2*2}.",
 # Or a data frame
 str_interp("Values are $[.2f]{max(Sepal.Width)} and $[.2f]{min(Sepal.Width)}.",
            iris)
+
+# Use a formula and hyphens when the string is long
+max_char <- 80
+str_interp(~"This particular line is so long that it is hard to write "-
+  "without breaking the ${max_char}-char barrier!")
 }
 \author{
 Stefan Milton Bache

--- a/tests/testthat/test-interp.r
+++ b/tests/testthat/test-interp.r
@@ -38,3 +38,27 @@ test_that("str_interp works with nested expressions", {
   expect_that(s, is_identical_to("Works with } nested { braces too: 5348.00"))
 
 })
+
+test_that("str_interp works in the absense of placeholders", {
+
+  s <- str_interp("A quite static string here.")
+
+  expect_that(s, is_identical_to("A quite static string here."))
+
+})
+
+test_that("str_interp allows for hyphenation to concatenate strings", {
+
+  github_url <- "https://github.com/hadley/stringr"
+  issues <- "https://github.com/hadley/stringr/issues"
+
+  s <- str_interp(~"You may find the development page at ${github_url} "-
+                   "and file any issues at ${issues}.")
+
+  expect_that(s, is_identical_to(
+    "You may find the development page at https://github.com/hadley/stringr and file any issues at https://github.com/hadley/stringr/issues."))
+
+})
+
+
+

--- a/tests/testthat/test-interp.r
+++ b/tests/testthat/test-interp.r
@@ -61,4 +61,15 @@ test_that("str_interp allows for hyphenation to concatenate strings", {
 })
 
 
+test_that("str_interp fails when encountering nested placeholders", {
 
+  msg  <- "This will never see the light of day"
+  num  <- 1.2345
+
+  expect_error(str_interp("You cannot use nested placeholders, e.g. ${${msg}}"),
+                          "Invalid template string for interpolation")
+
+  expect_error(str_interp("Nor can you with formats, e.g. $[.2f]{${msg}}"),
+               "Invalid template string for interpolation")
+
+})


### PR DESCRIPTION
This update does two things: 

1. `str_interp` would fail when no placeholders were found in the input string. This is fixed.
2. Added a suggested feature that makes it easier to break a long single-line string in multiple lines of source code without needing to use e.g  `paste`. Instead if the input string is a formula, hyphens (dashes) can be used to concatenate long strings: 

```R
max_char <- 80
str_interp(~"This particular line is so long that it is hard to write "-
            "without breaking the ${max_char}-char barrier!")
```

Here `str_interp` uses an internal utility function `unwrap_string_formula` which will recognize `-` as a hyphen (and not as a minus).