### PR TITLE
Add str_match to "See Also" of str_extract

### DIFF
--- a/man/str_extract.Rd
+++ b/man/str_extract.Rd
@@ -54,6 +54,7 @@ str_extract_all(shopping_list, "\\\\b[a-z]+\\\\b", simplify = TRUE)
 str_extract_all(shopping_list, "\\\\d", simplify = TRUE)
 }
 \seealso{
+\code{\link{str_match}} to extract capture groups,
 \code{\link[stringi]{stri_extract}} for the underlying
   implementation.
 }


### PR DESCRIPTION
This completes the symmetry of str_match referring to str_extract in its
own "See Also" section.

Fixes #93.