### PR TITLE
docs: fix word default value grammar

### DIFF
--- a/R/word.R
+++ b/R/word.R
@@ -4,7 +4,7 @@
 #' @param start,end Pair of integer vectors giving range of words (inclusive)
 #'   to extract. If negative, counts backwards from the last word.
 #'
-#'   The default value select the first word.
+#'   The default value selects the first word.
 #' @param sep Separator between words. Defaults to single space.
 #' @return A character vector with the same length as `string`/`start`/`end`.
 #' @export


### PR DESCRIPTION
Fixes #600

Changes:
- `The default value select the first word.` -> `The default value selects the first word.` in `R/word.R` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).
