### PR TITLE
fix: str_replace_all() error with named input and function replacement

### DIFF
--- a/R/replace.R
+++ b/R/replace.R
@@ -223,13 +223,14 @@ str_transform_all <- function(
   replacement,
   error_call = caller_env()
 ) {
+  nms <- names(string)
   locs <- str_locate_all(string, pattern)
 
   old <- str_sub_all(string, locs)
 
   # unchop list into a vector, apply replacement(), and then rechop back into
   # a list
-  old_flat <- vctrs::list_unchop(old)
+  old_flat <- vctrs::list_unchop(unname(old))
   if (length(old_flat) == 0) {
     # minor optimisation to avoid problems with the many replacement
     # functions that use paste
@@ -271,6 +272,7 @@ str_transform_all <- function(
   new <- vctrs::vec_chop(new_flat, idx)
 
   stringi::stri_sub_all(string, locs) <- new
+  names(string) <- nms
   string
 }
 

--- a/tests/testthat/test-replace.R
+++ b/tests/testthat/test-replace.R
@@ -153,6 +153,17 @@ test_that("replace functions preserve names", {
   expect_equal(names(str_replace_all(x, "[0-9]", "x")), names(x))
 })
 
+test_that("str_replace_all works with named input and function replacement (#595)", {
+  expect_equal(
+    str_replace_all(c(name = "string string"), "string", function(x) rep("strong", length(x))),
+    c(name = "strong strong")
+  )
+  expect_equal(
+    str_replace_all(c(a = "a1 b2", b = "c3"), "[a-z]", toupper),
+    c(a = "A1 B2", b = "C3")
+  )
+})
+
 test_that("replace functions handle vectorised patterns and names", {
   x1 <- c(A = "ab")
   p2 <- c("a", "b")


### PR DESCRIPTION
Fixes #595

## Problem

`str_replace_all()` errors when all three conditions are met:
1. `string` is a named character vector
2. `replacement` is a function
3. The pattern matches multiple times in at least one element

```r
str_replace_all(c(name = "string string"), "string", function(x) rep("strong", length(x)))
#> Error in vctrs::list_unchop():
#> ! Can't merge the outer name 'name' with a vector of length > 1.
```

## Root Cause

`str_transform_all()` passes the named list from `str_sub_all()` directly to `vctrs::list_unchop()`, which can't propagate outer names when inner vectors have length > 1. This was introduced when the function switched from `unlist()` to `list_unchop()`.

## Fix

Three minimal changes in `str_transform_all()` (`R/replace.R`):
1. Save `names(string)` before processing
2. Use `unname(old)` in `list_unchop()`
3. Restore names after replacement

## Tests

- Added test for the exact bug scenario (named input + function replacement + multiple matches)
- Added test with multiple named elements and function replacement
- All existing tests pass: `FAIL: 0 | WARN: 0 | SKIP: 39 | PASS: all remaining`
