### PR TITLE
tests: add edge-case tests for str_remove() and str_remove_all()

### DIFF
--- a/tests/testthat/test-remove.R
+++ b/tests/testthat/test-remove.R
@@ -7,3 +7,30 @@ test_that("str_remove() preserves names", {
   x <- c(C = "3", B = "2", A = "1")
   expect_equal(names(str_remove(x, "[0-9]")), names(x))
 })
+
+test_that("NA values pass through unchanged", {
+  expect_equal(str_remove(NA, "a"), NA_character_)
+  expect_equal(str_remove_all(NA, "a"), NA_character_)
+  expect_equal(str_remove(c(NA, "abc"), "b"), c(NA, "ac"))
+  expect_equal(str_remove_all(c(NA, "ababa"), "ba"), c(NA, "a"))
+})
+
+test_that("empty strings pass through unchanged", {
+  expect_equal(str_remove("", "a"), "")
+  expect_equal(str_remove_all("", "a"), "")
+})
+
+test_that("zero-length input returns zero-length output", {
+  expect_equal(str_remove(character(), "a"), character())
+  expect_equal(str_remove_all(character(), "a"), character())
+})
+
+test_that("factor input is handled correctly", {
+  expect_equal(str_remove(factor("abc"), "b"), "ac")
+  expect_equal(str_remove_all(factor("ababa"), "ba"), "a")
+})
+
+test_that("no match returns string unchanged", {
+  expect_equal(str_remove("abc", "z"), "abc")
+  expect_equal(str_remove_all("abc", "z"), "abc")
+})


### PR DESCRIPTION
## Summary

Adds edge-case test coverage for `str_remove()` and `str_remove_all()`:
- **NA handling**: Tests that both functions correctly propagate `NA` values (single and mixed with non-NA)
- **Empty strings**: Tests behavior with empty string input
- **Zero-length vectors**: Tests that `character()` input returns `character()`
- **Factor input**: Tests factor-to-character coercion works correctly
- **No match**: Tests that non-matching patterns return the original string

## Motivation

`str_remove()` and `str_remove_all()` are thin wrappers around `str_replace()`/`str_replace_all()`, but the test file (9 lines) had zero coverage for these common data-cleaning edge cases. The DESCRIPTION claims all functions deal with NAs and zero-length vectors consistently — these tests verify that claim for the remove family.

## Tests run

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 15 ]
```

All 15 remove tests pass (5 new test blocks, 13 new assertions). Full suite has 2 pre-existing snapshot failures (lifecycle wording changes), unrelated to this work.