### PR TITLE
tests: add edge-case tests for str_count()

### DIFF
--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -37,3 +37,28 @@ test_that("str_count() preserves names when pattern and string have same length"
   p2 <- c("a", "c")
   expect_equal(names(str_count(x2, p2)), names(x2))
 })
+
+test_that("str_count() handles NA values", {
+  expect_equal(str_count(NA, "a"), NA_integer_)
+  expect_equal(str_count(c("a", NA, "b"), "a"), c(1L, NA_integer_, 0L))
+})
+
+test_that("str_count() handles empty strings", {
+  expect_equal(str_count("", "a"), 0L)
+  expect_equal(str_count(character(), "a"), integer())
+})
+
+test_that("str_count() errors on NA pattern", {
+  expect_error(str_count("abc", NA_character_), "can not contain NAs")
+})
+
+test_that("str_count() counts non-overlapping regex matches", {
+  expect_equal(str_count("aaa", regex("aa")), 1L)
+  expect_equal(str_count("aaaa", regex("aa")), 2L)
+  expect_equal(str_count("ababab", "ab"), 3L)
+})
+
+test_that("str_count() handles multibyte characters", {
+  expect_equal(str_count("\u00e9\u00e8\u00ea", regex("[\u00e9\u00e8\u00ea]")), 3L)
+  expect_equal(str_count("\u4e2d\u6587\u6d4b\u8bd5", "\u6587"), 1L)
+})


### PR DESCRIPTION
## Summary

Adds edge-case tests for `str_count()` covering data cleaning scenarios that were previously untested.

## Tests Added

1. **NA input handling** — `str_count(NA, "a")` returns `NA_integer_`; vector with mixed NA propagates correctly
2. **Empty string input** — `str_count("", "a")` returns `0L`; empty character vector returns `integer()`
3. **NA pattern errors** — `str_count("abc", NA_character_)` errors with informative message
4. **Non-overlapping regex matches** — Verifies correct counting of non-overlapping regex matches (e.g., `"aaa"` with `"aa"` counts 1, `"aaaa"` counts 2)
5. **Multibyte characters** — Counting accented characters and CJK characters works correctly

## Validation

- All 22 tests pass (was 12 before): `devtools::load_all(); test_file('tests/testthat/test-count.R')`
- No regressions in existing tests
- No snapshot files needed (uses `expect_error()` instead of `expect_snapshot()` for error test)

## Files Changed

- `tests/testthat/test-count.R` — Added 25 lines (5 test blocks)