### PR TITLE
tests: add edge-case tests for str_pad()

### DIFF
--- a/tests/testthat/_snaps/pad.md
+++ b/tests/testthat/_snaps/pad.md
@@ -1,0 +1,16 @@
+# str_pad() validates inputs
+
+    Code
+      str_pad("a", 5, side = "top")
+    Condition
+      Error in `str_pad()`:
+      ! `side` must be one of "left", "right", or "both", not "top".
+
+---
+
+    Code
+      str_pad("a", 5, use_width = "yes")
+    Condition
+      Error in `str_pad()`:
+      ! `use_width` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/test-pad.R
+++ b/tests/testthat/test-pad.R
@@ -43,3 +43,86 @@ test_that("str_pad() preserves names", {
   x <- c(C = "3", B = "2", A = "1")
   expect_equal(names(str_pad(x, 2, side = "left")), names(x))
 })
+
+test_that("str_pad() handles NA values", {
+  expect_equal(str_pad(NA_character_, 5), NA_character_)
+  expect_equal(str_pad(c("a", NA, "b"), 5), c("    a", NA, "    b"))
+  expect_equal(
+    str_pad(c("a", NA), 5, side = "right"),
+    c("a    ", NA)
+  )
+  expect_equal(
+    str_pad(c("a", NA), 5, side = "both"),
+    c("  a  ", NA)
+  )
+})
+
+test_that("str_pad() handles empty strings", {
+  expect_equal(str_pad("", 5), "     ")
+  expect_equal(str_pad("", 5, side = "right"), "     ")
+  expect_equal(str_pad("", 5, side = "both"), "     ")
+  expect_equal(str_pad("", 0), "")
+  expect_equal(str_pad("", 1), " ")
+})
+
+test_that("str_pad() handles empty character(0)", {
+  expect_equal(str_pad(character(0), 5), character(0))
+  expect_equal(str_pad(character(0), 5, side = "right"), character(0))
+})
+
+test_that("str_pad() respects custom pad character", {
+  expect_equal(str_pad("a", 5, pad = "0"), "0000a")
+  expect_equal(str_pad("a", 5, pad = "-"), "----a")
+  expect_equal(str_pad("a", 5, side = "right", pad = "."), "a....")
+  expect_equal(str_pad("a", 5, side = "both", pad = "*"), "**a**")
+})
+
+test_that("str_pad() handles width of 0", {
+  expect_equal(str_pad("hello", 0), "hello")
+  expect_equal(str_pad("a", 0), "a")
+  expect_equal(str_pad("", 0), "")
+})
+
+test_that("str_pad() does not pad when width equals string width", {
+  expect_equal(str_pad("abc", 3), "abc")
+  expect_equal(str_pad("abc", 3, side = "right"), "abc")
+  expect_equal(str_pad("abc", 3, side = "both"), "abc")
+})
+
+test_that("str_pad() does not pad when width is less than string width", {
+  expect_equal(str_pad("hello", 3), "hello")
+  expect_equal(str_pad("hello", 1), "hello")
+  expect_equal(str_pad("hello", 0), "hello")
+})
+
+test_that("str_pad() vectorises width", {
+  expect_equal(str_pad("a", c(3, 5, 7)), c("  a", "    a", "      a"))
+  expect_equal(
+    str_pad("a", c(3, 5), side = "right"),
+    c("a  ", "a    ")
+  )
+})
+
+test_that("str_pad() vectorises pad", {
+  expect_equal(str_pad("a", 5, pad = c("0", "-")), c("0000a", "----a"))
+  expect_equal(
+    str_pad("a", 5, side = "right", pad = c(".", "*")),
+    c("a....", "a****")
+  )
+})
+
+test_that("str_pad() preserves names for all sides", {
+  x <- c(A = "a", B = "b")
+  expect_equal(names(str_pad(x, 5, side = "left")), c("A", "B"))
+  expect_equal(names(str_pad(x, 5, side = "right")), c("A", "B"))
+  expect_equal(names(str_pad(x, 5, side = "both")), c("A", "B"))
+})
+
+test_that("str_pad() validates inputs", {
+  expect_snapshot(error = TRUE, {
+    str_pad("a", 5, side = "top")
+  })
+  expect_snapshot(error = TRUE, {
+    str_pad("a", 5, use_width = "yes")
+  })
+})


### PR DESCRIPTION
## Summary

Adds edge-case tests for `str_pad()` covering common data cleaning scenarios that had limited test coverage.

## Rationale

`str_pad()` is a key text formatting function used in data cleaning pipelines (e.g., padding IDs to fixed width, formatting numeric codes, aligning text for display). The existing test file (45 lines, 9 expectations) only covered:

1. Long strings unchanged (random test)
2. Directions (left/right/both) with simple case
3. Chinese character width
4. Recycling rules
5. Names preservation (left side only)

Missing coverage for common data cleaning scenarios:

1. **NA value handling** — No tests for NA preservation through padding
2. **Empty input** — Empty string and empty character vector untested
3. **Custom pad characters** — Only default space tested
4. **Width of 0** — Behavior with zero width untested
5. **Boundary widths** — Width equal to or less than string width untested
6. **Vectorised width** — Element-wise width processing untested
7. **Vectorised pad** — Element-wise pad character processing untested
8. **Names preservation** — Only left side tested; right and both untested

## Tests Added (12 test blocks, 33 new expectations)

1. `str_pad() handles NA values` — Single NA, mixed NA/vector, NA with right/both sides
2. `str_pad() handles empty strings` — Empty string with all sides, width 0, width 1
3. `str_pad() handles empty character(0)` — Empty vector with left and right sides
4. `str_pad() respects custom pad character` — 0, -, ., * with all sides
5. `str_pad() handles width of 0` — No padding applied
6. `str_pad() does not pad when width equals string width` — All sides
7. `str_pad() does not pad when width is less than string width` — Width 3, 1, 0
8. `str_pad() vectorises width` — Left and right sides
9. `str_pad() vectorises pad` — Left and right sides
10. `str_pad() preserves names for all sides` — Left, right, both
11. `str_pad() validates inputs` — Invalid side, invalid use_width type

## Validation

- `Rscript -e 'devtools::test(filter = "pad")'` — 0 failures, 42 passes (9 existing + 33 new)
- Full test suite: 2 pre-existing snapshot mismatches in `test-sub.R` (unrelated), all other tests pass
- No regressions in existing tests