### PR TITLE
tests: add edge-case tests for str_flatten() and str_flatten_comma()

### DIFF
--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -24,3 +24,43 @@ test_that("str_flatten_oxford removes comma iif necessary", {
   expect_equal(str_flatten_comma(letters[1:3], " or "), "a, b or c")
   expect_equal(str_flatten_comma(letters[1:3]), "a, b, c")
 })
+
+test_that("str_flatten handles empty input with last", {
+  expect_equal(str_flatten(character(), ", ", " and "), "")
+  expect_equal(str_flatten(character(), "-"), "")
+})
+
+test_that("str_flatten handles single element with last", {
+  expect_equal(str_flatten("a", ", ", " and "), "a")
+  expect_equal(str_flatten("a", "-"), "a")
+})
+
+test_that("str_flatten handles all-NA input with na.rm", {
+  expect_equal(str_flatten(c(NA, NA), na.rm = TRUE), "")
+  expect_equal(str_flatten(NA_character_, na.rm = TRUE), "")
+})
+
+test_that("str_flatten_comma handles empty input with last", {
+  expect_equal(str_flatten_comma(character(), ", or "), "")
+  expect_equal(str_flatten_comma(character()), "")
+})
+
+test_that("str_flatten_comma handles single element with last", {
+  expect_equal(str_flatten_comma("a", ", or "), "a")
+  expect_equal(str_flatten_comma("a"), "a")
+})
+
+test_that("str_flatten_comma handles NA with last and na.rm", {
+  expect_equal(
+    str_flatten_comma(c("a", NA, "b"), ", or ", na.rm = TRUE),
+    "a, or b"
+  )
+  expect_equal(
+    str_flatten_comma(c(NA, "a", "b"), ", or ", na.rm = TRUE),
+    "a, or b"
+  )
+  expect_equal(
+    str_flatten_comma(c("a", "b", NA), ", or ", na.rm = TRUE),
+    "a, or b"
+  )
+})


### PR DESCRIPTION
## Summary

Adds edge-case tests for `str_flatten()` and `str_flatten_comma()` covering empty input, single-element input, all-NA input, and NA handling with the `last` parameter.

## Motivation

`str_flatten()` and `str_flatten_comma()` are common data cleaning functions for collapsing character vectors into summary strings. The existing tests cover basic usage but miss several edge cases relevant to data cleaning pipelines:

- Empty input with `last` parameter
- Single-element input with `last` parameter  
- All-NA input with `na.rm = TRUE`
- `str_flatten_comma()` with empty input
- `str_flatten_comma()` with NA values, `last`, and `na.rm`

## Tests Added (7 test blocks)

1. **str_flatten handles empty input with last** — Empty character vector with `last` parameter
2. **str_flatten handles single element with last** — Single element with `last` parameter
3. **str_flatten handles all-NA input with na.rm** — All-NA with `na.rm = TRUE`
4. **str_flatten_comma handles empty input with last** — Empty input with `last` parameter
5. **str_flatten_comma handles single element with last** — Single element with `last`
6. **str_flatten_comma handles NA with last and na.rm** — NA in various positions with `last` and `na.rm`

## Validation

- `Rscript -e 'testthat::test_file("tests/testthat/test-flatten.R")'` — 0 failures, 23 passes
- No regressions in existing tests